### PR TITLE
feat: auto read the data folder, no need for fix name, add file argv directly also

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ find_package(Open3D HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
 list(APPEND Open3D_LIBRARIES dl)
 
 message(STATUS "Found Open3D ${Open3D_VERSION}")
-
 link_directories(${Open3D_LIBRARY_DIRS})
 
 add_subdirectory(patchworkpp)
@@ -35,10 +34,10 @@ add_subdirectory(python_wrapper)
 add_executable(demo_visualize examples/cpp/demo_visualize.cpp)
 target_link_libraries(demo_visualize PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES})
 target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
-set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/examples/cpp")
+set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
 
 add_executable(demo_sequential examples/cpp/demo_sequential.cpp)
 target_link_libraries(demo_sequential PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES})
 target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
-set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/examples/cpp")
+set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ $ ./examples/cpp/demo_visualize
 
 # Run patchwork++ with sequential point cloud inputs 
 $ ./examples/cpp/demo_sequential
+
+# Run patchwork++ with your point cloud file, example here
+$ ./examples/cpp/demo_visualize /home/kin/data/1670247988.bin
 ```
 
 ### Demo Result

--- a/examples/cpp/demo_sequential.cpp
+++ b/examples/cpp/demo_sequential.cpp
@@ -3,6 +3,9 @@
 #include <iostream>
 #include <fstream>
 #include <open3d/Open3D.h>
+// for list folder
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 
 using namespace open3d;
 
@@ -53,10 +56,10 @@ int main() {
 
   patchwork::PatchWorkpp Patchworkpp(patchwork_parameters);
 
-  for (int i=0; i<6; i++)
+  for (const fs::directory_entry & entry : fs::directory_iterator(data_dir))
   {
     // Load point cloud
-    std::string file = data_dir + "00000" + std::to_string(i) + ".bin";
+    std::string file = entry.path().c_str();
     Eigen::MatrixXf cloud;
     read_bin(file, cloud);
 

--- a/examples/cpp/demo_visualize.cpp
+++ b/examples/cpp/demo_visualize.cpp
@@ -9,7 +9,7 @@ using namespace open3d;
 int filename_length = std::string("demo_visaulize.cpp").length();
 std::string file_dir = std::string(__FILE__);
 std::string data_dir = file_dir.substr(0, file_dir.size()-filename_length) + "../../data/";
-std::string input_cloud_filepath = data_dir + "000000.bin";
+
 
 void read_bin(std::string bin_path, Eigen::MatrixXf &cloud)
 {
@@ -44,10 +44,20 @@ void addNormals(Eigen::MatrixXf normals, std::shared_ptr<geometry::PointCloud> g
 }
 
 
-int main() {
+int main(int argc, char* argv[]) {
 
   cout << "Execute" << __FILE__ << endl;
-  
+  // Get the dataset
+  std::string input_cloud_filepath;
+  if (argc < 2) {
+    // Try out running on the test datasets.
+    input_cloud_filepath = data_dir + "000000.bin";
+    std::cout << "\033[1;33mNo file path specified; defaulting to the test "
+                    "directory. \033[0m" << std::endl;
+  } else {
+    input_cloud_filepath = argv[1];
+    std::cout << "\033[1;32mLoading 3DMatch files from " << input_cloud_filepath << "\033[0m" << std::endl;
+  }
   // Patchwork++ initialization
   patchwork::Params patchwork_parameters;
   patchwork_parameters.verbose = true;

--- a/examples/cpp/demo_visualize.cpp
+++ b/examples/cpp/demo_visualize.cpp
@@ -4,6 +4,10 @@
 #include <fstream>
 #include <open3d/Open3D.h>
 
+// for list folder
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
 using namespace open3d;
 
 int filename_length = std::string("demo_visaulize.cpp").length();
@@ -52,12 +56,17 @@ int main(int argc, char* argv[]) {
   if (argc < 2) {
     // Try out running on the test datasets.
     input_cloud_filepath = data_dir + "000000.bin";
-    std::cout << "\033[1;33mNo file path specified; defaulting to the test "
-                    "directory. \033[0m" << std::endl;
+    std::cout << "\033[1;33mNo point cloud file path specified; defaulting to the test directory. \033[0m" << std::endl;
   } else {
     input_cloud_filepath = argv[1];
-    std::cout << "\033[1;32mLoading 3DMatch files from " << input_cloud_filepath << "\033[0m" << std::endl;
+    std::cout << "\033[1;32mLoading point cloud files from " << input_cloud_filepath << "\033[0m" << std::endl;
   }
+  if(!fs::exists(input_cloud_filepath)){
+    std::cout << "\033[1;31mERROR HERE: maybe wrong data file path, please check the path or remove argv to run default one. \033[0m" 
+              << "\nThe file path you provide is: " << input_cloud_filepath << std::endl;
+    return 0;
+  }
+
   // Patchwork++ initialization
   patchwork::Params patchwork_parameters;
   patchwork_parameters.verbose = true;


### PR DESCRIPTION
Check the commit to see the modification.

1. It's more convenient for people to directly copy their point cloud file in the `data` folder and run it. No need to rename all of them.
2. for a single file demo, add the `argv` also for convenience.

Test command:
```bash
mkdir build && cd build
cmake .. && make -j$(nproc)

# example here
./examples/cpp/demo_visualize /home/kin/data/1670247988.bin
```



