### PR TITLE
Separate building and python install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.11)
 project(PATCHWORK VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -10,9 +10,13 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${Open3D_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Open3D_CXX_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${Open3D_EXE_LINKER_FLAGS}")
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+if(CMAKE_VERSION VERSION_LESS "3.15")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ListPrepend.cmake")
+  list_prepend(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+else()
+  list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+endif()
 
-include(FetchContent)
 
 list(APPEND Open3D_LIBRARIES dl)
 
@@ -20,18 +24,18 @@ add_subdirectory(patchworkpp)
 
 if (INCLUDE_PYTHON_WRAPPER)
 
-  message("Building Python wrapper")
+  message(STATUS "Building Python wrapper")
   find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+  include(FetchContent)
   include(pybind11)
   add_subdirectory(python_wrapper)
-
+  
 endif()
 
 if (INCLUDE_EXAMPLES)
 
   message(STATUS "Building examples for c++")
   find_package(Open3D REQUIRED HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
-
 
   list(APPEND Open3D_LIBRARIES dl)
   link_directories(${Open3D_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.19)
 project(PATCHWORK VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -18,25 +18,56 @@ else()
 endif()
 
 include(FetchContent)
-include(pybind11)
+# include(pybind11)
 
-find_package(Eigen3 REQUIRED QUIET)
-find_package(Open3D HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
+# find_package(Eigen3 REQUIRED QUIET)
 list(APPEND Open3D_LIBRARIES dl)
 
-message(STATUS "Found Open3D ${Open3D_VERSION}")
-link_directories(${Open3D_LIBRARY_DIRS})
-
 add_subdirectory(patchworkpp)
-add_subdirectory(python_wrapper)
 
-add_executable(demo_visualize examples/cpp/demo_visualize.cpp)
-target_link_libraries(demo_visualize PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES} "stdc++fs")
-target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
-set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
+if (INCLUDE_PYTHON_WRAPPER)
 
-add_executable(demo_sequential examples/cpp/demo_sequential.cpp)
-target_link_libraries(demo_sequential PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES} "stdc++fs")
-target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
-set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
+  message("Building Python wrapper")
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+
+  list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
+  include(pybind11)
+
+  add_subdirectory(python_wrapper)
+
+endif()
+
+if (INCLUDE_EXAMPLES)
+  message("Building examples for c++")
+
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Open3D/)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Open3D ${CMAKE_CURRENT_BINARY_DIR}/Open3D)
+  else()
+
+    message(STATUS "Downloading Open3D C++")
+    include(FetchContent)
+    FetchContent_Declare(
+      ext_Open3D PREFIX Open3D
+      URL https://github.com/isl-org/Open3D/archive/refs/tags/v0.17.0.tar.gz SOURCE_SUBDIR
+      Open3D)
+    FetchContent_MakeAvailable(ext_Open3D)
+  endif()
+
+
+  find_package(Open3D HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
+  link_directories(${Open3D_LIBRARY_DIRS})
+  message(STATUS "Found Open3D ${Open3D_VERSION}")
+
+  add_executable(demo_visualize examples/cpp/demo_visualize.cpp)
+  target_link_libraries(demo_visualize PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES} "stdc++fs")
+  target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
+  set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
+
+  add_executable(demo_sequential examples/cpp/demo_sequential.cpp)
+  target_link_libraries(demo_sequential PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES} "stdc++fs")
+  target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
+  set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
+
+endif()
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${Open3D_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Open3D_CXX_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${Open3D_EXE_LINKER_FLAGS}")
 
-if(CMAKE_VERSION VERSION_LESS "3.15")
-  include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ListPrepend.cmake")
-  list_prepend(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-else()
-  list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-endif()
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(FetchContent)
-# include(pybind11)
 
-# find_package(Eigen3 REQUIRED QUIET)
 list(APPEND Open3D_LIBRARIES dl)
 
 add_subdirectory(patchworkpp)
@@ -29,32 +22,18 @@ if (INCLUDE_PYTHON_WRAPPER)
 
   message("Building Python wrapper")
   find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
-
-  list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
   include(pybind11)
-
   add_subdirectory(python_wrapper)
 
 endif()
 
 if (INCLUDE_EXAMPLES)
-  message("Building examples for c++")
 
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Open3D/)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Open3D ${CMAKE_CURRENT_BINARY_DIR}/Open3D)
-  else()
-
-    message(STATUS "Downloading Open3D C++")
-    include(FetchContent)
-    FetchContent_Declare(
-      ext_Open3D PREFIX Open3D
-      URL https://github.com/isl-org/Open3D/archive/refs/tags/v0.17.0.tar.gz SOURCE_SUBDIR
-      Open3D)
-    FetchContent_MakeAvailable(ext_Open3D)
-  endif()
+  message(STATUS "Building examples for c++")
+  find_package(Open3D REQUIRED HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
 
 
-  find_package(Open3D HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
+  list(APPEND Open3D_LIBRARIES dl)
   link_directories(${Open3D_LIBRARY_DIRS})
   message(STATUS "Found Open3D ${Open3D_VERSION}")
 
@@ -69,5 +48,3 @@ if (INCLUDE_EXAMPLES)
   set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build/examples/cpp")
 
 endif()
-
-

--- a/examples/python/demo_sequential.py
+++ b/examples/python/demo_sequential.py
@@ -1,19 +1,11 @@
 import os
-import sys
 import open3d as o3d
 import numpy as np
-# import pypatchworkpp
+import pypatchworkpp
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(cur_dir, '../../data/')
 
-try:
-    patchwork_module_path = os.path.join(cur_dir, "../../build/python_wrapper")
-    sys.path.insert(0, patchwork_module_path)
-    import pypatchworkpp
-except ImportError:
-    print("Cannot find pypatchworkpp!")
-    exit(1)
 
 def read_bin(bin_path):
     scan = np.fromfile(bin_path, dtype=np.float32)

--- a/examples/python/demo_visualize.py
+++ b/examples/python/demo_visualize.py
@@ -2,18 +2,11 @@ import os
 import sys
 import open3d as o3d
 import numpy as np
-# import pypatchworkpp
+import pypatchworkpp
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 input_cloud_filepath = os.path.join(cur_dir, '../../data/000000.bin')
 
-try:
-    patchwork_module_path = os.path.join(cur_dir, "../../build/python_wrapper")
-    sys.path.insert(0, patchwork_module_path)
-    import pypatchworkpp
-except ImportError:
-    print("Cannot find pypatchworkpp!")
-    exit(1)
 
 def read_bin(bin_path):
     scan = np.fromfile(bin_path, dtype=np.float32)

--- a/install_open3d.bash
+++ b/install_open3d.bash
@@ -4,10 +4,6 @@ VERSION=0.15.1
 
 [ ! -d Open3D ] && git clone https://github.com/isl-org/Open3D.git -b v$VERSION || echo "Skip pulling repo"
 
-# cd Open3D
-# cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_EXAMPLES=OFF -DBUILD_PYTHON_MODULE=OFF -DBUILD_ISPC_MODULE=OFF -DBUILD_WEBRTC=OFF --install ./build -S ./ -B ./build
-
-
 [ ! -d Open3D/build ] && mkdir Open3D/build
 cd Open3D/build
 
@@ -22,4 +18,5 @@ cmake .. \
 
 make -j$(nproc)
 
+echo "Applying 'sudo make install'. Enter password"
 sudo make install

--- a/install_open3d.bash
+++ b/install_open3d.bash
@@ -1,0 +1,25 @@
+set -e
+
+VERSION=0.15.1
+
+[ ! -d Open3D ] && git clone https://github.com/isl-org/Open3D.git -b v$VERSION || echo "Skip pulling repo"
+
+# cd Open3D
+# cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_EXAMPLES=OFF -DBUILD_PYTHON_MODULE=OFF -DBUILD_ISPC_MODULE=OFF -DBUILD_WEBRTC=OFF --install ./build -S ./ -B ./build
+
+
+[ ! -d Open3D/build ] && mkdir Open3D/build
+cd Open3D/build
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -Wno-dev \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_PYTHON_MODULE=OFF \
+    -DBUILD_ISPC_MODULE=OFF \
+    -DBUILD_WEBRTC=OFF
+
+
+make -j$(nproc)
+
+sudo make install

--- a/patchworkpp/CMakeLists.txt
+++ b/patchworkpp/CMakeLists.txt
@@ -2,7 +2,11 @@ project(patchworkpp_src)
 
 include(GNUInstallDirs)
 
-add_library(patchworkpp SHARED src/patchworkpp.cpp)
+find_package(Eigen3 REQUIRED QUIET)
+
+add_library(patchworkpp STATIC src/patchworkpp.cpp)
+set_target_properties(patchworkpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(patchworkpp PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["scikit_build_core", "pybind11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "pypatchworkpp"
+version = "0.0.1"
+dependencies = [
+	"numpy>=1.23"
+]
+
+[project.optional-dependencies]
+demo = [
+	"open3d-cpu>=0.17"
+]
+
+[tool.scikit-build]
+cmake.args = ["-DINCLUDE_PYTHON_WRAPPER=true"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "pypatchworkpp"
 version = "0.0.1"
+requires-python = ">=3.8"
+description = "ground segmentation"
 dependencies = [
 	"numpy>=1.23"
 ]

--- a/python_wrapper/CMakeLists.txt
+++ b/python_wrapper/CMakeLists.txt
@@ -1,18 +1,11 @@
-cmake_minimum_required(VERSION 3.16)
-
-
-project(pypatchworkpp LANGUAGES CXX)
-
-#find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
-
-#list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
-#include(pybind11)
-
-# add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../patchworkpp patchworkpp)
-
+project(patchworkpp_python_wrapper LANGUAGES CXX)
 
 pybind11_add_module(pypatchworkpp pybinding.cpp)
 
-target_link_libraries(pypatchworkpp PRIVATE patchworkpp)
+target_link_libraries(pypatchworkpp PUBLIC PATCHWORK::patchworkpp)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(pypatchworkpp PUBLIC -fsized-deallocation)
+endif()
 
 install(TARGETS pypatchworkpp DESTINATION .)

--- a/python_wrapper/CMakeLists.txt
+++ b/python_wrapper/CMakeLists.txt
@@ -1,9 +1,18 @@
-project(patchworkpp_python_wrapper)
+cmake_minimum_required(VERSION 3.16)
+
+
+project(pypatchworkpp LANGUAGES CXX)
+
+#find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+
+#list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
+#include(pybind11)
+
+# add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../patchworkpp patchworkpp)
+
 
 pybind11_add_module(pypatchworkpp pybinding.cpp)
 
-target_link_libraries(pypatchworkpp PUBLIC PATCHWORK::patchworkpp)
+target_link_libraries(pypatchworkpp PRIVATE patchworkpp)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  target_compile_options(pypatchworkpp PUBLIC -fsized-deallocation)
-endif()
+install(TARGETS pypatchworkpp DESTINATION .)


### PR DESCRIPTION
Hello! I slightly modified CMakeLists and few other things to be able to install this package in python environment and to avoid using of Open3D in case the examples are not necessary.

Main changes:
- Main CMakeLists.txt: arguments to enable compiling python wrapper and C++ examples;
- patchworkpp/CMakeLists.txt: changes SHARED to STATIC (only with static linking python binaries are installed correctly) and moved Eigen requirement  from base CMakeLists.txt;
- python_wrapper/CMakeLists.txt: added INSTALL command
- python examples: get rid of try...except in ```import pypatchworkpp```
- Added bash script for minimal Open3D installation to visualize C++ examples. I tried to include fetching in CMakeLists to automate it, but without success.
- pyproject.toml: config file for python installation.

Now the project can be installed like any other python package with pip:
```pip install .```

Maybe, You'd want to upload it to PyPI. This would be very useful!.

 