### PR TITLE
Better instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+pyinstall:
+	@python3 -m pip install --upgrade pip
+	@pip install numpy
+	@pip install --verbose ./python/
+
+pyinstall_with_demo: pyinstall
+	@pip install open3d==0.18.0
+
+cppinstall:
+	@cmake -Bcpp/build cpp/
+	@cmake --build cpp/build -j$(nproc --all)
+
+cppinstall_with_demo:
+	@cmake -Bcpp/build cpp/ -DINCLUDE_CPP_EXAMPLES=ON
+	@cmake --build cpp/build -j$(nproc --all)

--- a/README.md
+++ b/README.md
@@ -45,56 +45,66 @@
 [examplelink]: https://github.com/url-kaist/patchwork-plusplus/tree/master/examples
 
 ## :package: Prerequisite packages
+> What we need are just minimal dependencies.
 
-> [!WARNING]  
-> Please check your cmake version via `cmake --version`. If it is lower than 3.20, please run `scripts/install_latest_cmake.bash` as follows:
-> 
-> $ bash scripts/install_latest_cmake.bash
-> 
-> In addition, you may need to install Eigen, numpy, and Open3D (optional). Open3D is used for point cloud visualization.
-
-
-<details>
-<summary> Step-by-Step Installation Guide for Beginners </summary>
-
-```bash
-# To install Eigen and numpy
-$ sudo apt-get install libeigen3-dev
-$ pip install numpy
-
-# To install Open3D Python packages
-$ pip install open3d
-
-# To install Open3D C++ packages
-$ git clone https://github.com/isl-org/Open3D
-$ cd Open3D
-$ util/install_deps_ubuntu.sh # Only needed for Ubuntu
-$ mkdir build && cd build
-$ cmake ..
-$ make # If it fails, try several times or try 'sudo make'
-$ sudo make install
+```commandline
+sudo apt-get install g++ build-essential libeigen3-dev python3-pip python3-dev cmake -y
 ```
 
 </details>
 
 ## :gear: How to build & Run
-> Please follow below codes to build Patchwork++.
-
 
 ### Python
-```bash
+
+**Pure installation**
+
+```commandline
 make pyinstall
 ```
 
-Detailed installation instructions and how to run the demo are explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/python).
+Then, you can use Patchwork++ by `import pypatchworkpp`, which is super simple!
+
+**Installation to run demo**
+
+Only Open3D (> 0.17.0) is additionally installed for visualization purposes.
+
+```commandline
+make pyinstall_with_demo
+```
+
+How to run Python demos is explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/python/README.md#Demo).
 
 ### C++
 
-```bash
+**Pure installation**
+
+```commandline
 make cppinstall
 ```
 
-Detailed installation instructions and how to run the demo are explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/cpp).
+**Installation with demo**
+
+Only Open3D (> 0.17.0) is additionally installed for visualization purposes.
+
+```commandline
+make cppinstall_with_demo
+```
+
+How to run the C++ demos is explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/cpp).
+
+### ROS2
+
+You should not need any extra dependency, just clone and build:
+
+```commandline
+cd colcon_ws/src && git clone 
+cd ../../
+colcon build --packages-select patchworkpp
+```
+
+How to launch ROS2 nodes is explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/cpp).
+
 
 ## :pencil: Citation
 If you use our codes, please cite our paper ([arXiv][arXivLink], [IEEE *Xplore*][patchworkppIEEElink])

--- a/README.md
+++ b/README.md
@@ -148,3 +148,12 @@ If you have any questions, please do not hesitate to contact us
 
 [sjlink]: https://github.com/seungjae24
 [htlink]: https://github.com/LimHyungTae
+
+
+---
+
+## Todo List
+- [ ] Support intensity for RNR in `master` branch
+- [ ] Support `Patchwork` mode for users who use this repository for baseline comparison purposes
+- [ ] Integrate TBB and optimize the performance
+

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@
 [examplelink]: https://github.com/url-kaist/patchwork-plusplus/tree/master/examples
 
 ## :package: Prerequisite packages
-> You may need to install Eigen, numpy, and Open3D. Open3D is used for point cloud visualization.
 
-```bash
-# Install prerequisite packages including Open3D
-$ git clone https://github.com/url-kaist/patchwork-plusplus
-$ cd patchwork-plusplus
-$ bash scripts/install_open3d.bash
-```
+> [!WARNING]  
+> Please check your cmake version via `cmake --version`. If it is lower than 3.20, please run `scripts/install_latest_cmake.bash` as follows:
+> 
+> $ bash scripts/install_latest_cmake.bash
+> 
+> In addition, you may need to install Eigen, numpy, and Open3D (optional). Open3D is used for point cloud visualization.
+
 
 <details>
-<summary> Manual Installation line-by-line </summary>
+<summary> Step-by-Step Installation Guide for Beginners </summary>
 
 ```bash
 # To install Eigen and numpy
@@ -77,54 +77,24 @@ $ sudo make install
 
 </details>
 
-## :gear: How to build
+## :gear: How to build & Run
 > Please follow below codes to build Patchwork++.
 
-### Python
-```bash
-# in patchwork-plusplus directory
-$ cd python && pip install . 
-```
-
-### C++
-```bash
-# in patchwork-plusplus directory
-$ mkdir cpp/build && cd cpp/build
-$ cmake ..
-$ make
-```
-
-## :runner: To run the demo codes
-> There are some example codes for your convenience!
-> Please try using Patchwork++ to segment ground points in a 3D point cloud :smiley:
 
 ### Python
 ```bash
-# Run patchwork++ and visualize ground points(green) and nonground points(red)
-$ python examples/demo_visualize.py
-
-# Run patchwork++ with sequential point cloud inputs 
-$ python examples/demo_sequential.py
+make pyinstall
 ```
+
+Detailed installation instructions and how to run the demo are explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/python).
 
 ### C++
+
 ```bash
-# Run patchwork++ and visualize ground points(green) and nonground points(red)
-$ ./examples/demo_visualize
-
-# Run patchwork++ with sequential point cloud inputs 
-$ ./examples/demo_sequential
-
-# Run patchwork++ with your point cloud file, example here
-$ ./examples/demo_visualize ./data/000000.bin # specify file path
+make cppinstall
 ```
 
-### Demo Result
-If you execute Patchwork++ with given demo codes well, you can get the following result!
-
-It is a ground segmentation result of data/000000.bin file using Open3D visualization. (Ground : Green, Nonground : Red)
-
-![Open3D Visualization of "data/000000.bin"](pictures/demo_000000.png)
+Detailed installation instructions and how to run the demo are explained [here](https://github.com/url-kaist/patchwork-plusplus/tree/master/cpp).
 
 ## :pencil: Citation
 If you use our codes, please cite our paper ([arXiv][arXivLink], [IEEE *Xplore*][patchworkppIEEElink])

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.11)
-project(PATCHWORK VERSION 1.0.0)
+project(patchworkpp VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 20)
 set(PYTHON_EXECUTABLE python3)
 set(CMAKE_BUILD_TYPE Release)
-
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${Open3D_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Open3D_CXX_FLAGS}")
@@ -17,30 +16,37 @@ else()
   list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 endif()
 
+option(BUILD_CPP_EXAMPLES "Build C++ example codes, which require Open3D for visualization" OFF)
 
-list(APPEND Open3D_LIBRARIES dl)
+# Parameters in `patchworkpp` subdirectory.
+# Thus, link should be `patchworkpp::ground_seg_cores`
+set(PARENT_PROJECT_NAME ${PROJECT_NAME})
+set(TARGET_NAME ground_seg_cores)
 
 add_subdirectory(patchworkpp)
 
-set(INCLUDE_EXAMPLES ON CACHE BOOL "Build examples")
-
-if (INCLUDE_EXAMPLES)
-
-  message(STATUS "Building examples for c++")
-  find_package(Open3D REQUIRED HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
-
+if (BUILD_CPP_EXAMPLES)
   list(APPEND Open3D_LIBRARIES dl)
-  link_directories(${Open3D_LIBRARY_DIRS})
-  message(STATUS "Found Open3D ${Open3D_VERSION}")
+  set(INCLUDE_EXAMPLES ON CACHE BOOL "Build examples")
 
-  add_executable(demo_visualize ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_visualize.cpp)
-  target_link_libraries(demo_visualize PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES} "stdc++fs")
-  target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
-  set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+  if (INCLUDE_EXAMPLES)
 
-  add_executable(demo_sequential ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_sequential.cpp)
-  target_link_libraries(demo_sequential PRIVATE PATCHWORK::patchworkpp ${Open3D_LIBRARIES} "stdc++fs")
-  target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
-  set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+    message(STATUS "Building examples for c++")
+    find_package(Open3D REQUIRED HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
 
+    list(APPEND Open3D_LIBRARIES dl)
+    link_directories(${Open3D_LIBRARY_DIRS})
+    message(STATUS "Found Open3D ${Open3D_VERSION}")
+
+    add_executable(demo_visualize ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_visualize.cpp)
+    target_link_libraries(demo_visualize PRIVATE ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${Open3D_LIBRARIES} "stdc++fs")
+    target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
+    set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+    add_executable(demo_sequential ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_sequential.cpp)
+    target_link_libraries(demo_sequential PRIVATE ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${Open3D_LIBRARIES} "stdc++fs")
+    target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
+    set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+  endif()
 endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
   list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 endif()
 
-option(BUILD_CPP_EXAMPLES "Build C++ example codes, which require Open3D for visualization" OFF)
+option(INCLUDE_CPP_EXAMPLES "Include C++ example codes, which require Open3D for visualization" OFF)
 
 # Parameters in `patchworkpp` subdirectory.
 # Thus, link should be `patchworkpp::ground_seg_cores`
@@ -25,28 +25,38 @@ set(TARGET_NAME ground_seg_cores)
 
 add_subdirectory(patchworkpp)
 
-if (BUILD_CPP_EXAMPLES)
-  list(APPEND Open3D_LIBRARIES dl)
-  set(INCLUDE_EXAMPLES ON CACHE BOOL "Build examples")
-
-  if (INCLUDE_EXAMPLES)
-
-    message(STATUS "Building examples for c++")
-    find_package(Open3D REQUIRED HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
-
-    list(APPEND Open3D_LIBRARIES dl)
-    link_directories(${Open3D_LIBRARY_DIRS})
-    message(STATUS "Found Open3D ${Open3D_VERSION}")
-
-    add_executable(demo_visualize ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_visualize.cpp)
-    target_link_libraries(demo_visualize PRIVATE ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${Open3D_LIBRARIES} "stdc++fs")
-    target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
-    set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
-
-    add_executable(demo_sequential ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_sequential.cpp)
-    target_link_libraries(demo_sequential PRIVATE ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${Open3D_LIBRARIES} "stdc++fs")
-    target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
-    set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
-
+if (INCLUDE_CPP_EXAMPLES)
+  if(CMAKE_VERSION VERSION_LESS "3.15")
+    # Just automatically update cmake version
+    execute_process(COMMAND bash ../scripts/install_latest.cmake.bash
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
+
+  list(APPEND Open3D_LIBRARIES dl)
+
+  message(STATUS "Building examples for c++")
+  find_package(Open3D QUIET)
+  if (NOT Open3D_FOUND)
+    message(STATUS "Open3D not found, installing Open3D...")
+    execute_process(COMMAND bash ../scripts/install_open3d.bash
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    find_package(Open3D REQUIRED HINTS ${CMAKE_INSTALL_PREFIX}/lib/CMake)
+  else()
+    message(STATUS "Found Open3D ${Open3D_VERSION}")
+  endif()
+
+  list(APPEND Open3D_LIBRARIES dl)
+  link_directories(${Open3D_LIBRARY_DIRS})
+  message(STATUS "Found Open3D ${Open3D_VERSION}")
+
+  add_executable(demo_visualize ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_visualize.cpp)
+  target_link_libraries(demo_visualize PRIVATE ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${Open3D_LIBRARIES} "stdc++fs")
+  target_include_directories(demo_visualize PUBLIC ${Open3D_INCLUDE_DIRS})
+  set_target_properties(demo_visualize PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
+  add_executable(demo_sequential ${CMAKE_CURRENT_SOURCE_DIR}/patchworkpp/examples/demo_sequential.cpp)
+  target_link_libraries(demo_sequential PRIVATE ${PARENT_PROJECT_NAME}::${TARGET_NAME} ${Open3D_LIBRARIES} "stdc++fs")
+  target_include_directories(demo_sequential PUBLIC ${Open3D_INCLUDE_DIRS})
+  set_target_properties(demo_sequential PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples")
+
 endif()

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,87 @@
+<div align="center">
+    <h1>Patchwork++</h1>
+    <a href="https://github.com/url-kaist/patchwork-plusplus/tree/master/patchworkpp"><img src="https://img.shields.io/badge/-C++-blue?logo=cplusplus" /></a>
+    <a href="https://github.com/url-kaist/patchwork-plusplus/tree/master"><img src="https://img.shields.io/badge/Python-3670A0?logo=python&logoColor=ffdd54" /></a>
+    <a href="https://github.com/url-kaist/patchwork-plusplus/tree/master/ros"><img src="https://img.shields.io/badge/ROS2-Humble-blue" /></a>
+    <a href="https://github.com/url-kaist/patchwork-plusplus/tree/master"><img src="https://img.shields.io/badge/Linux-FCC624?logo=linux&logoColor=black" /></a>
+    <a href="https://ieeexplore.ieee.org/document/9981561"><img src="https://img.shields.io/badge/DOI-10.1109/IROS47612.2022.9981561-004088.svg"/>
+    <br />
+    <br />
+    <a href=https://www.youtube.com/watch?v=fogCM159GRk>Video</a>
+    <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+    <a href="https://github.com/url-kaist/patchwork-plusplus/tree/master/README.md###Python">Install</a>
+    <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+    <a href="https://github.com/url-kaist/patchwork-plusplus/tree/master/ros">ROS2</a>
+    <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+    <a href=https://www.youtube.com/watch?v=fogCM159GRk>Paper</a>
+    <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+    <a href=https://github.com/url-kaist/patchwork-plusplus/issues>Contact Us</a>
+  <br />
+  <br />
+  <p align="center"><img src=../pictures/patchwork++.gif alt="animated" /></p>
+
+  [Patchwork++][arXivlink], an extension of [Patchwork][patchworklink], is **a fast, robust, and self-adaptive ground segmentation algorithm** on 3D point cloud.
+</div>
+
+[arXivlink]: https://arxiv.org/abs/2207.11919
+[patchworklink]: https://github.com/LimHyungTae/patchwork
+
+---
+
+# Patchwork++ in C++
+
+## Manual Installation Just in Case
+
+```commandline
+# in patchwork-plusplus directory
+$ cd cpp && mkdir build && cd build
+$ cmake -DCMAKE_BUILD_TYPE=Release ..
+$ make -j 16
+```
+
+If you want to run demo, just run
+
+```commandline
+make cppinstall_with_demo
+```
+
+in the top-level directory, or 
+
+```commandline
+# in patchwork-plusplus directory
+$ cd cpp && mkdir build && cd build
+$ cmake -DCMAKE_BUILD_TYPE=Release -DINCLUDE_CPP_EXAMPLES=ON ..
+$ make -j 16
+```
+
+> [!WARNING]  
+> Please check your cmake version via `cmake --version`.
+> If it is lower than 3.20, it is automatically updated by `scripts/install_latest_cmake.bash` (see [here](https://github.com/url-kaist/patchwork-plusplus/blob/master/cpp/CMakeLists.txt#L31)).
+
+## :runner: To run the demo codes
+> There are some example codes for your convenience!
+> Please try using Patchwork++ to segment ground points in a 3D point cloud :smiley:
+
+
+* Example 1. Run patchwork++ and visualize ground points (green) and non-ground points (red)
+```commandline
+./cpp/build/examples/demo_visualize
+```
+
+* Example 2. Run patchwork++ with sequential point cloud inputs 
+```commandline
+./cpp/build/examples/demo_sequential
+```
+
+* Example 3. Run patchwork++ with your point cloud file, example here
+```commandline
+./examples/demo_visualize ./data/000000.bin # specify file path
+```
+
+### Demo Result
+If you execute Patchwork++ with given demo codes well, you can get the following result!
+
+It is a ground segmentation result of data/000000.bin file using Open3D visualization. (Ground : Green, Nonground : Red)
+
+![Open3D Visualization of "data/000000.bin"](../pictures/demo_000000.png)
+

--- a/cpp/patchworkpp/CMakeLists.txt
+++ b/cpp/patchworkpp/CMakeLists.txt
@@ -2,32 +2,34 @@ project(patchworkpp_src)
 
 include(GNUInstallDirs)
 
+message("Parent project name: " ${PARENT_PROJECT_NAME})
+
 find_package(Eigen3 REQUIRED QUIET)
 
-add_library(patchworkpp STATIC src/patchworkpp.cpp)
-set_target_properties(patchworkpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_library(${TARGET_NAME} STATIC src/patchworkpp.cpp)
+set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(patchworkpp PUBLIC
+target_include_directories(${TARGET_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_link_libraries(patchworkpp Eigen3::Eigen)
-add_library(PATCHWORK::patchworkpp ALIAS patchworkpp)
+target_link_libraries(${TARGET_NAME} Eigen3::Eigen)
+add_library(${PARENT_PROJECT_NAME}::${TARGET_NAME} ALIAS ${TARGET_NAME})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
   DESTINATION include
 )
-install(TARGETS patchworkpp
-  EXPORT PATCHWORKConfig
+install(TARGETS ${TARGET_NAME}
+  EXPORT ${PARENT_PROJECT_NAME}Config
   LIBRARY DESTINATION lib
 )
 
-export(TARGETS patchworkpp
-  NAMESPACE PATCHWORK::
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/PATCHWORKConfig.cmake"
+export(TARGETS ${TARGET_NAME}
+  NAMESPACE ${PARENT_PROJECT_NAME}::
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PARENT_PROJECT_NAME}Config.cmake"
 )
-install(EXPORT PATCHWORKConfig
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/PATCHWORK/cmake"
-  NAMESPACE PATCHWORK::
+install(EXPORT ${PARENT_PROJECT_NAME}Config
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/${PARENT_PROJECT_NAME}/cmake"
+  NAMESPACE ${PARENT_PROJECT_NAME}::
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Parameters used in `patchworkpp` subdirectory.
+# Thus, link should be `patchworkpp::ground_seg_cores`
+# See https://github.com/url-kaist/patchwork-plusplus/tree/master/cpp/CMakeLists.txt#L21
+set(PARENT_PROJECT_NAME patchworkpp)
+set(TARGET_NAME ground_seg_cores)
+
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 
@@ -21,7 +27,7 @@ endif()
 
 pybind11_add_module(pypatchworkpp patchworkpp/pybinding.cpp)
 
-target_link_libraries(pypatchworkpp PUBLIC PATCHWORK::patchworkpp)
+target_link_libraries(pypatchworkpp PUBLIC ${PARENT_PROJECT_NAME}::${TARGET_NAME})
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(pypatchworkpp PUBLIC -fsized-deallocation)

--- a/python/README.md
+++ b/python/README.md
@@ -20,7 +20,7 @@
   <br />
   <p align="center"><img src=../pictures/patchwork++.gif alt="animated" /></p>
 
-[Patchwork++][arXivlink], an extension of [Patchwork][patchworklink], is **a fast, robust, and self-adaptive ground segmentation algorithm** on 3D point cloud.
+  [Patchwork++][arXivlink], an extension of [Patchwork][patchworklink], is **a fast, robust, and self-adaptive ground segmentation algorithm** on 3D point cloud.
 </div>
 
 [arXivlink]: https://arxiv.org/abs/2207.11919
@@ -28,33 +28,25 @@
 
 ---
 
-# Patchwork++ ROS2 Wrapper
+# Patchwork++ in Python
 
-### How to build
+## :runner: To run the demo codes
+> There are some example codes for your convenience!
+> Please try using Patchwork++ to segment ground points in a 3D point cloud :smiley:
 
-You should not need any extra dependency, just clone and build:
-
-```sh
-git clone https://github.com/url-kaist/patchwork-plusplus.git
-colcon build --packages-select patchworkpp
-source ./install/setup.bash 
+* Example 1. Run patchwork++ and visualize ground points (green) and non-ground points (red)
+```commandline
+python python/examples/demo_visualize.py
 ```
 
-### How to run
-
-The only required argument to provide is the **topic name** so Patchwork++ knows which PointCloud2 to process:
-
-```sh
-ros2 launch patchworkpp.launch.py visualize:=false use_sim_time:=true topic:=/lexus3/os_center/points base_frame:=lexus3/os_center_a_laser_data_frame
+* Example 2. Run patchwork++ with sequential point cloud inputs 
+```commandline
+python python/examples/demo_sequential.py
 ```
 
-and then,
+### Demo Result
+If you execute Patchwork++ with given demo codes well, you can get the following result!
 
-```
-ros2 bag play lexus3-2024-04-05-gyor.mcap --loop
-```
+It is a ground segmentation result of data/000000.bin file using Open3D visualization. (Ground : Green, Nonground : Red)
 
-```sh
-rviz2 -d patchworkpp.rviz
-```
-
+![Open3D Visualization of "data/000000.bin"](../pictures/demo_000000.png)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pypatchworkpp"
-version = "0.0.1"
+version = "0.1.0"
 requires-python = ">=3.8"
 description = "ground segmentation"
 dependencies = [

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -5,6 +5,12 @@ set(ignore ${CATKIN_INSTALL_INTO_PREFIX_ROOT})
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Parameters used in `patchworkpp` subdirectory.
+# Thus, link should be `patchworkpp::ground_seg_cores`
+# See https://github.com/url-kaist/patchwork-plusplus/tree/master/cpp/CMakeLists.txt#L21
+set(PARENT_PROJECT_NAME patchworkpp)
+set(TARGET_NAME ground_seg_cores)
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp ${CMAKE_CURRENT_BINARY_DIR}/patchworkpp_cpp)
 else()
@@ -27,7 +33,7 @@ find_package(tf2_ros REQUIRED)
 add_library(gseg_component SHARED src/GroundSegmentationServer.cpp)
 target_compile_features(gseg_component PUBLIC cxx_std_20)
 target_include_directories(gseg_component PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(gseg_component PATCHWORK::patchworkpp)
+target_link_libraries(gseg_component ${PARENT_PROJECT_NAME}::${TARGET_NAME})
 ament_target_dependencies(
   gseg_component
   rcutils

--- a/ros/README.md
+++ b/ros/README.md
@@ -35,26 +35,37 @@
 You should not need any extra dependency, just clone and build:
 
 ```sh
+mkdir -p ~/ros2_ws/src
 git clone https://github.com/url-kaist/patchwork-plusplus.git
+cd ~/ros2_ws
 colcon build --packages-select patchworkpp
 source ./install/setup.bash 
 ```
 
-### How to run
+## :runner: To run the demo codes
+There is a demo that executes Patchwork++ with a sample rosbag2 (mcap) file. You can download a sample file using the following command.
+
+> [!TIP]
+> Please install mcap library as follows:
+> 
+> sudo apt install ros-humble-rosbag2-storage-mcap
+> 
+> Then, download a sample dataset for ros2: [mcap file download [~540MB] ](https://laesze-my.sharepoint.com/:u:/g/personal/herno_o365_sze_hu/Eclwzn42FS9GunGay5LPq-EBA6U1dZseBFNDrr6P0MwB2w?download=1)
+
 
 The only required argument to provide is the **topic name** so Patchwork++ knows which PointCloud2 to process:
 
 ```sh
-ros2 launch patchworkpp.launch.py visualize:=false use_sim_time:=true topic:=/lexus3/os_center/points base_frame:=lexus3/os_center_a_laser_data_frame
+ros2 launch patchworkpp patchworkpp.launch.py visualize:=true use_sim_time:=true cloud_topic:=/lexus3/os_center/points base_frame:=lexus3/os_center_a_laser_data_frame
 ```
 
-and then,
+and then, play rosbag as follows:
 
 ```
 ros2 bag play lexus3-2024-04-05-gyor.mcap --loop
 ```
 
-```sh
-rviz2 -d patchworkpp.rviz
-```
+Consequently, we can see the results in Rviz:
+
+![img](../pictures/patchwork2_in_ros2.gif)
 

--- a/ros/src/GroundSegmentationServer.cpp
+++ b/ros/src/GroundSegmentationServer.cpp
@@ -43,6 +43,9 @@ GroundSegmentationServer::GroundSegmentationServer(const rclcpp::NodeOptions &op
 
   params.verbose = get_parameter<bool>("verbose", params.verbose);
 
+  // ToDo. Support intensity
+  params.enable_RNR = false;
+
   // Construct the main Patchwork++ node
   Patchworkpp_ = std::make_unique<patchwork::PatchWorkpp>(params);
 

--- a/scripts/install_latest_cmake.bash
+++ b/scripts/install_latest_cmake.bash
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-SUDO=${SUDO:=sudo} # SUDO=command in docker (running as root, sudo not available)
+command_exists() {
+  command -v "$@" >/dev/null 2>&1
+}
+
+user_can_sudo() {
+  command_exists sudo || return 1
+  ! LANG= sudo -n -v 2>&1 | grep -q "may not run sudo"
+}
+
+if user_can_sudo; then
+SUDO="sudo"
+else
+SUDO="" # To support docker environment
+fi
+
 if [ "$1" == "assume-yes" ]; then
     APT_CONFIRM="--assume-yes"
 else

--- a/scripts/install_latest_cmake.bash
+++ b/scripts/install_latest_cmake.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+SUDO=${SUDO:=sudo} # SUDO=command in docker (running as root, sudo not available)
+if [ "$1" == "assume-yes" ]; then
+    APT_CONFIRM="--assume-yes"
+else
+    APT_CONFIRM=""
+fi
+
+$SUDO apt-get update -y
+$SUDO apt-get install git libeigen3-dev python3-pip -y
+
+# Install CMake > 3.20 for Open3D 0.18.0 version
+# Please refer to 'https://apt.kitware.com/'
+$SUDO apt-get install ca-certificates gpg wget -y
+test -f /usr/share/doc/kitware-archive-keyring/copyright ||
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | $SUDO tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+
+echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | $SUDO tee /etc/apt/sources.list.d/kitware.list >/dev/null
+$SUDO apt-get update -y
+$SUDO apt-get install cmake -y

--- a/scripts/install_latest_cmake.bash
+++ b/scripts/install_latest_cmake.bash
@@ -25,6 +25,7 @@ fi
 $SUDO apt-get update -y
 $SUDO apt-get install git libeigen3-dev python3-pip -y
 
+echo -e "\e[33mThe version of your cmake is too low. Installing the latest cmake...\e[0m"
 # Install CMake > 3.20 for Open3D 0.18.0 version
 # Please refer to 'https://apt.kitware.com/'
 $SUDO apt-get install ca-certificates gpg wget -y

--- a/scripts/install_open3d.bash
+++ b/scripts/install_open3d.bash
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-SUDO=${SUDO:=sudo} # SUDO=command in docker (running as root, sudo not available)
+command_exists() {
+  command -v "$@" >/dev/null 2>&1
+}
+
+user_can_sudo() {
+  command_exists sudo || return 1
+  ! LANG= sudo -n -v 2>&1 | grep -q "may not run sudo"
+}
+
+if user_can_sudo; then
+SUDO="sudo"
+else
+SUDO="" # To support docker environment
+fi
+
 if [ "$1" == "assume-yes" ]; then
     APT_CONFIRM="--assume-yes"
 else

--- a/scripts/install_open3d.bash
+++ b/scripts/install_open3d.bash
@@ -23,17 +23,6 @@ else
 fi
 
 $SUDO apt-get update -y
-$SUDO apt-get install git libeigen3-dev python3-pip -y
-
-# Install CMake > 3.20 for Open3D 0.18.0 version
-# Please refer to 'https://apt.kitware.com/'
-$SUDO apt-get install ca-certificates gpg wget -y
-test -f /usr/share/doc/kitware-archive-keyring/copyright ||
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | $SUDO tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-
-echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | $SUDO tee /etc/apt/sources.list.d/kitware.list >/dev/null
-$SUDO apt-get update -y
-$SUDO apt-get install cmake -y
 
 # To update the recent version of open3d
 python3 -m pip install --upgrade pip


### PR DESCRIPTION
I believe no one likes to follow installation instructions, which is a bit annoying.

In addition, we don't need to install Open3D, which is a bit heavy library once a user does not want to visualize results. 

So I 
* first make a shell script for the upgrade of `cmake` (8c74465 and 98456a4)
* set Makefile for better usability (f161150)

As a result, Open3D is automatically installed depending on the condition (see Makefile and `DINCLUDE_CPP_EXAMPLES` option)

Finally, I separate a single README.md (b60a404) into C++, Python, and ROS2 (646e38e, 17ebe44).

In addition, I rename the name of the package and link library to `patchworkpp` and `ground_seg_cores`, respectively. 