### PR TITLE
Fix bugs of error C2065: “M_PI” not defined in Windows

### DIFF
--- a/cpp/patchworkpp/include/patchwork/patchworkpp.h
+++ b/cpp/patchworkpp/include/patchwork/patchworkpp.h
@@ -1,6 +1,10 @@
 #ifndef PATCHWORKPP_H
 #define PATCHWORKPP_H
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 #include <iostream>
 #include <vector>
 #include <Eigen/Dense>


### PR DESCRIPTION
Nmake in Visual Studio doesn't have definition of "M_PI", so we should mannually add it to the header file to support installation in Windows platform.