### PR TITLE
EigenMatToPointCloud2 - Use rows() of Eigen::Matrix3f &points

### DIFF
--- a/ros/src/Utils.hpp
+++ b/ros/src/Utils.hpp
@@ -189,7 +189,7 @@ inline std::unique_ptr<PointCloud2> EigenToPointCloud2(const std::vector<Eigen::
 
 inline std::unique_ptr<PointCloud2> EigenMatToPointCloud2(const Eigen::MatrixX3f &points,
                                                           const Header &header) {
-  auto msg = CreatePointCloud2Msg(points.size(), header);
+  auto msg = CreatePointCloud2Msg(points.rows(), header);
   FillPointCloud2XYZ(points, *msg);
   return msg;
 }


### PR DESCRIPTION
The usage of points.size() in EigenMatToPointCloud2 to CreatePointCloudMsg() was incorrect, it should have been points.rows().

Using points.size() leads to 3x more points being allocated in the point cloud than necessary which bloats the message slowing things down. These extra points are at the origin of the pointcloud. This can manifest as an artificial hump directly under the origin of the point cloud.