### PR TITLE
ci(pypi): skip PyPy wheels so the v1.1.0 release can publish

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Build all wheels
         if: github.event_name == 'release'
         uses: pypa/cibuildwheel@v2.21.3
+        env:
+          # PyPy lacks the C API symbols pybind11 needs (PyModule_GetFilenameObject etc.).
+          # Restrict to CPython only — PyPy native-extension support is not a goal here.
+          CIBW_SKIP: "pp*"
         with:
           package-dir: ${{github.workspace}}/python/
 


### PR DESCRIPTION
## Summary

The v1.1.0 release workflow failed because cibuildwheel defaults to building both CPython and PyPy, and PyPy lacks the C API symbols pybind11 expects (`PyModule_GetFilenameObject`, etc.). All 6 CPython targets (cp38–cp313) built fine — only the 3 PyPy targets failed, and that fail-fast'd the whole job, so PyPI never received the wheels.

This adds `CIBW_SKIP: "pp*"` to the release wheel build step. PyPy support for pybind11 native extensions is not a goal of this project, so skipping is the right move (rather than patching around upstream gaps).

## After this merges

I will re-create the v1.1.0 GitHub Release at the new master HEAD; that re-fires the publish workflow, which now skips PyPy and uploads CPython wheels + sdist to PyPI.

## Test plan

- [x] Test wheels job (PR/push, `CIBW_BUILD: "cp310-*"`) keeps working unchanged
- [ ] Release wheels job will skip pp38/pp39/pp310 and produce 6 CPython × 3 OS = 18 wheels (verified after merge + re-release)