### PR TITLE
fix: use fixed-size Eigen vectors for plane-fit members (resolves #62)

### DIFF
--- a/cpp/patchworkpp/include/patchwork/patchworkpp.h
+++ b/cpp/patchworkpp/include/patchwork/patchworkpp.h
@@ -188,10 +188,10 @@ class PatchWorkpp {
 
   double d_;
 
-  Eigen::VectorXf normal_;
-  Eigen::VectorXf singular_values_;
+  Eigen::Vector3f normal_;
+  Eigen::Vector3f singular_values_;
   Eigen::Matrix3f cov_;
-  Eigen::VectorXf pc_mean_;
+  Eigen::Vector3f pc_mean_;
 
   vector<double> min_ranges_;
   vector<double> sector_sizes_;


### PR DESCRIPTION
## Summary

Replaces `Eigen::VectorXf` with `Eigen::Vector3f` for `normal_`, `singular_values_`, and `pc_mean_` in `cpp/patchworkpp/include/patchwork/patchworkpp.h`.

The dynamic vectors are accessed at fixed indices (e.g. `pc_mean_(0)`, `singular_values_.minCoeff()`) before being sized, which crashes at startup when the input is a partial (non-360°) point cloud — for example, the OS1 128 Ouster pointcloud reported in #62 that does not start at azimuth 0.

The fix matches the maintainer's own recommendation in #62 and the SVD output type (`JacobiSVD<MatrixX3f>` returns a `Vector3f` for singular values and `matrixU().col(2)` is a `Vector3f`).

## Why this re-issues #72 instead of merging it

#72 had the correct fix but the commit was unsigned, and master now requires signed commits. This PR re-applies the same diff with `MatteGombia` as author and a signed committer, plus a `Co-authored-by:` trailer for full credit.

#66 attempted the same fix but used `Vector2f` for `singular_values_`, which would silently change ground segmentation behavior because `singular_values_.minCoeff()` (used as the flatness measure at `cpp/patchworkpp/src/patchworkpp.cpp:221`) operates on the third (smallest) singular value — that's the one perpendicular to the fit plane.

## Test plan

- [x] cpp build clean on macOS arm64 (FetchContent Eigen 3.4)
- [x] pytest 4/4 pass (2 patchworkpp + 2 patchwork) on `data/000000.bin`
- [ ] CI matrix (Ubuntu 22/24, Windows, macOS 14, ROS humble/jazzy)

## Closes

- #62 (Question about input pointcloud → crash on partial pointclouds)
- supersedes #66 and #72