### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(patchworkpp VERSION 1.1.0)
+project(patchworkpp VERSION 1.2.0)
 
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" OFF)
 option(INCLUDE_CPP_EXAMPLES "Include C++ example codes, which require Open3D for visualization" OFF)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pypatchworkpp"
-version = "1.1.0"
+version = "1.2.0"
 requires-python = ">=3.8"
 description = "ground segmentation"
 dependencies = [


### PR DESCRIPTION
## Summary

Bumps version 1.1.0 → 1.2.0 in `python/pyproject.toml` and `cpp/CMakeLists.txt`.

## What's in 1.2.0 since 1.1.0

- #81 — fix: \`Eigen::VectorXf\` → \`Eigen::Vector3f\` for plane-fit members. Fixes startup crash on partial (non-360°) point clouds (e.g. OS1 128 Ouster) reported in #62.

## After merge

I will create the v1.2.0 GitHub Release at master HEAD; the existing pypi.yml workflow handles wheel builds (CPython 3.8–3.13 × Linux/Windows/macOS arm64) and PyPI upload automatically.