### PR TITLE
fix(patchworkpp): clear ringwise_flatness every ring (#69)

### DIFF
--- a/cpp/patchworkpp/src/patchworkpp.cpp
+++ b/cpp/patchworkpp/src/patchworkpp.cpp
@@ -300,8 +300,12 @@ void PatchWorkpp::estimateGround(Eigen::MatrixXf cloud_in) {
         }
 
         candidates.clear();
-        ringwise_flatness.clear();
       }
+      // ringwise_flatness must be cleared every ring; the previous
+      // placement inside `if (!candidates.empty())` leaked flatnesses
+      // from no-candidate rings into the next ring's TGR statistics
+      // (see issue #69).
+      ringwise_flatness.clear();
       clock_t t_aft_revert = clock();
 
       t_revert += t_aft_revert - t_bef_revert;


### PR DESCRIPTION
## What

Move `ringwise_flatness.clear()` outside the `if (!candidates.empty())` block in `cpp/patchworkpp/src/patchworkpp.cpp` so it runs unconditionally at the end of every ring iteration.

```diff
       if (!candidates.empty()) {
         if (params_.enable_TGR) {
           temporal_ground_revert(ringwise_flatness, candidates, concentric_idx);
         } else {
           for (auto candidate : candidates) {
             addCloud(cloud_nonground_, candidate.regionwise_ground);
           }
         }
         candidates.clear();
-        ringwise_flatness.clear();
       }
+      ringwise_flatness.clear();
```

## Why

Reported by @KennethBlomqvist in #69. The previous placement only cleared `ringwise_flatness` when the current ring produced at least one revert candidate. If a ring finished with `candidates` empty, the accumulated flatnesses leaked into the next ring's `temporal_ground_revert` call and polluted its `mean ± stdev` statistics. Since flatness statistics differ across CZM rings (closer rings are flatter by construction), this biased the revert decision threshold (`mu_flatness = mean + 1.5 * stdev`, line 435).

Impact in practice is small because most rings DO produce candidates, so TGR fires every ring on KITTI. But the bug is real and the fix is one line.

## Numerical impact — KITTI 00–10, full 23,201 frames, Patchwork++ paper protocol

| Build | P | R | F1 |
|---|---|---|---|
| v1.3.0 baseline | 95.5494 | 97.1649 | 96.2886 |
| **This PR**     | **95.5496** | **97.1710** | **96.2918** |

ΔF1 = +0.003 (within run-to-run noise). Confirms no regression.

## Test plan

- [x] One-line code change verified by reading the immediately-surrounding loop (the only callsite of `temporal_ground_revert`).
- [x] `pip install -v ./python/` from a clean conda env succeeds.
- [x] Smoke test seq 00 first 50 frames → numbers within ±0.1 of v1.3.0.
- [x] Full KITTI 00–10 sweep with `--method patchworkpp --eval_protocol patchworkpp` → table above.

Closes #69.