### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v1.3.1
+
+### Bug fix — `pypatchworkpp.patchworkpp` (Patchwork++)
+
+- `ringwise_flatness` is now cleared at the end of every ring iteration
+  in `cpp/patchworkpp/src/patchworkpp.cpp`, not only when the ring had
+  revert candidates. The previous placement leaked flatnesses from
+  no-candidate rings into the next ring's `temporal_ground_revert` call,
+  biasing the revert decision threshold. Reported by @KennethBlomqvist
+  in #69. Closes #69.
+
+### Numerical impact
+
+KITTI 00–10 full sweep (23,201 frames) under the Patchwork++ paper
+protocol:
+
+| Build  | P       | R       | F1      |
+| ------ | ------- | ------- | ------- |
+| v1.3.0 | 95.5494 | 97.1649 | 96.2886 |
+| v1.3.1 | 95.5496 | 97.1710 | 96.2918 |
+
+ΔF1 = +0.003 (within run-to-run noise). The bug only triggered when a
+ring finished with no revert candidates, which is uncommon on KITTI;
+the macro-average impact is negligible but the fix is correctness.
+
 ## v1.3.0
 
 ### Performance enhancement — `pypatchworkpp.patchwork` (classic Patchwork reimpl)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(patchworkpp VERSION 1.3.0)
+project(patchworkpp VERSION 1.3.1)
 
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" OFF)
 option(INCLUDE_CPP_EXAMPLES "Include C++ example codes, which require Open3D for visualization" OFF)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pypatchworkpp"
-version = "1.3.0"
+version = "1.3.1"
 requires-python = ">=3.8"
 description = "ground segmentation"
 dependencies = [


### PR DESCRIPTION
## Summary

Patch release on top of v1.3.0. One bug fix only:

- #69 → #91 — `ringwise_flatness` is cleared every ring instead of only when revert candidates exist, so stale flatnesses no longer leak into the next ring's `temporal_ground_revert` mean/stdev. Numerical impact on KITTI 00–10 is +0.003 F1 (within run-to-run noise); fix is correctness.

Bumps:

- `python/pyproject.toml`: 1.3.0 → 1.3.1
- `cpp/CMakeLists.txt`: 1.3.0 → 1.3.1

CHANGELOG.md updated with the v1.3.1 entry.

After merge: cut a `v1.3.1` GitHub Release to trigger the PyPI publish workflow.