### PR TITLE
perf(patchworkpp): kill per-patch heap traffic in R-VPF / R-GPF (+14.8% Hz)

### DIFF
--- a/cpp/common/src/plane_fit.cpp
+++ b/cpp/common/src/plane_fit.cpp
@@ -19,16 +19,26 @@ void estimate_plane(const std::vector<PointXYZ>& seeds, PCAFeature& out, float t
   const Eigen::Matrix3f cov =
       (centered.adjoint() * centered) / std::max<float>(1.0f, static_cast<float>(pts.rows() - 1));
 
-  Eigen::JacobiSVD<Eigen::Matrix3f> svd(cov, Eigen::ComputeFullU);
-  Eigen::Vector3f normal = svd.matrixU().col(2);
+  // Closed-form 3x3 symmetric eigendecomposition. Covariance is PSD,
+  // so eigenvalues == singular values; eigenvectors come back ascending,
+  // so col(0) is the plane normal (smallest variance direction) and
+  // col(2) is the principal axis. Repack singular_values_ in descending
+  // order so the (s0 >= s1 >= s2) convention used by linearity / planarity
+  // and by downstream patchwork++ consumers (line_variable, ground_flatness)
+  // is preserved bit-for-bit relative to the previous JacobiSVD output.
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> eig;
+  eig.computeDirect(cov, Eigen::ComputeEigenvectors);
+  const Eigen::Vector3f evals = eig.eigenvalues().cwiseMax(0.0f);
+
+  Eigen::Vector3f normal = eig.eigenvectors().col(0);
   if (normal(2) < 0.0f) normal = -normal;
 
-  out.normal_          = normal;
-  out.principal_       = svd.matrixU().col(0);
-  out.singular_values_ = svd.singularValues();
-  out.mean_            = mean;
-  out.d_               = -normal.dot(mean);
-  out.th_dist_d_       = th_dist - out.d_;
+  out.normal_    = normal;
+  out.principal_ = eig.eigenvectors().col(2);
+  out.singular_values_ << evals(2), evals(1), evals(0);
+  out.mean_      = mean;
+  out.d_         = -normal.dot(mean);
+  out.th_dist_d_ = th_dist - out.d_;
 
   const float s0  = out.singular_values_(0);
   const float s1  = out.singular_values_(1);

--- a/cpp/patchworkpp/include/patchwork/patchworkpp.h
+++ b/cpp/patchworkpp/include/patchwork/patchworkpp.h
@@ -195,6 +195,13 @@ class PatchWorkpp {
   vector<PointXYZ> ground_pc_, non_ground_pc_;
   vector<PointXYZ> regionwise_ground_, regionwise_nonground_;
 
+  // Reused scratch buffers for R-VPF / R-GPF inside extract_piecewiseground.
+  // Promoting these to members avoids per-patch heap (de)allocation, which
+  // dominated the per-frame profile (~14 µs avg patch, hundreds of patches
+  // per cloud) — see issue #96.
+  vector<PointXYZ> src_wo_verticals_;
+  vector<PointXYZ> src_tmp_;
+
   vector<PointXYZ> cloud_ground_, cloud_nonground_;
 
   vector<PointXYZ> centers_, normals_;
@@ -202,7 +209,7 @@ class PatchWorkpp {
   Eigen::MatrixX3f toEigenCloud(const vector<PointXYZ> &cloud);
   Eigen::VectorXi toIndices(const vector<PointXYZ> &cloud);
 
-  void addCloud(vector<PointXYZ> &cloud, vector<PointXYZ> &add);
+  void addCloud(vector<PointXYZ> &cloud, const vector<PointXYZ> &add);
 
   void flush_patches(std::vector<Zone> &czm);
 
@@ -210,12 +217,12 @@ class PatchWorkpp {
 
   void reflected_noise_removal(Eigen::MatrixXf &cloud_in);
 
-  void temporal_ground_revert(std::vector<double> ring_flatness,
-                              std::vector<patchwork::RevertCandidate> candidates,
+  void temporal_ground_revert(const std::vector<double> &ring_flatness,
+                              const std::vector<patchwork::RevertCandidate> &candidates,
                               int concentric_idx);
 
-  double calc_point_to_plane_d(PointXYZ p, Eigen::VectorXf normal, double d);
-  void calc_mean_stdev(std::vector<double> vec, double &mean, double &stdev);
+  double calc_point_to_plane_d(const PointXYZ &p, const Eigen::VectorXf &normal, double d);
+  void calc_mean_stdev(const std::vector<double> &vec, double &mean, double &stdev);
 
   void update_elevation_thr();
   void update_flatness_thr();

--- a/cpp/patchworkpp/src/patchworkpp.cpp
+++ b/cpp/patchworkpp/src/patchworkpp.cpp
@@ -26,7 +26,7 @@ Eigen::VectorXi PatchWorkpp::toIndices(const vector<PointXYZ> &cloud) {
   return dst;
 }
 
-void PatchWorkpp::addCloud(vector<PointXYZ> &cloud, vector<PointXYZ> &add) {
+void PatchWorkpp::addCloud(vector<PointXYZ> &cloud, const vector<PointXYZ> &add) {
   cloud.insert(cloud.end(), add.begin(), add.end());
 }
 
@@ -49,34 +49,60 @@ void PatchWorkpp::flush_patches(vector<Zone> &czm) {
 void PatchWorkpp::estimate_plane(const vector<PointXYZ> &ground) {
   if (ground.empty()) return;
 
-  Eigen::MatrixX3f eigen_ground(ground.size(), 3);
-  int j = 0;
-  for (auto &p : ground) {
-    eigen_ground.row(j++) << p.x, p.y, p.z;
+  // Single-pass accumulation of mean + cross-products. Avoids the
+  // per-call Eigen::MatrixX3f / centered / adjoint-product heap
+  // allocations that dominated the profile. Cov is computed from the
+  // raw second moments via cov_ij = (sum p_i p_j - N * mean_i * mean_j) / (N - 1).
+  const size_t n = ground.size();
+  double sx = 0.0, sy = 0.0, sz = 0.0;
+  double sxx = 0.0, syy = 0.0, szz = 0.0;
+  double sxy = 0.0, sxz = 0.0, syz = 0.0;
+  for (const auto &p : ground) {
+    const double x = p.x, y = p.y, z = p.z;
+    sx += x;
+    sy += y;
+    sz += z;
+    sxx += x * x;
+    syy += y * y;
+    szz += z * z;
+    sxy += x * y;
+    sxz += x * z;
+    syz += y * z;
   }
-  Eigen::MatrixX3f centered = eigen_ground.rowwise() - eigen_ground.colwise().mean();
-  Eigen::MatrixX3f cov =
-      (centered.adjoint() * centered) / static_cast<double>(eigen_ground.rows() - 1);
+  const double inv_n = 1.0 / static_cast<double>(n);
+  const double mx = sx * inv_n, my = sy * inv_n, mz = sz * inv_n;
+  const double denom = (n > 1) ? static_cast<double>(n - 1) : 1.0;
+  const double inv_d = 1.0 / denom;
 
-  pc_mean_.resize(3);
-  pc_mean_ << eigen_ground.colwise().mean()(0), eigen_ground.colwise().mean()(1),
-      eigen_ground.colwise().mean()(2);
+  Eigen::Matrix3f cov;
+  cov(0, 0) = static_cast<float>((sxx - n * mx * mx) * inv_d);
+  cov(1, 1) = static_cast<float>((syy - n * my * my) * inv_d);
+  cov(2, 2) = static_cast<float>((szz - n * mz * mz) * inv_d);
+  cov(0, 1) = cov(1, 0) = static_cast<float>((sxy - n * mx * my) * inv_d);
+  cov(0, 2) = cov(2, 0) = static_cast<float>((sxz - n * mx * mz) * inv_d);
+  cov(1, 2) = cov(2, 1) = static_cast<float>((syz - n * my * mz) * inv_d);
 
-  Eigen::JacobiSVD<Eigen::MatrixX3f> svd(cov, Eigen::DecompositionOptions::ComputeFullU);
-  singular_values_ = svd.singularValues();
+  pc_mean_ << static_cast<float>(mx), static_cast<float>(my), static_cast<float>(mz);
 
-  // use the least singular vector as normal
-  normal_ = (svd.matrixU().col(2));
+  // Closed-form 3x3 symmetric eigendecomposition. Covariance is PSD,
+  // so eigenvalues == singular values; SelfAdjointEigenSolver returns
+  // them ascending. col(0) is the plane normal direction (smallest
+  // variance); singular_values_ is repacked in descending order so the
+  // downstream consumers in estimateGround (line_variable =
+  // singular_values_(0)/singular_values_(1), ground_flatness =
+  // singular_values_.minCoeff()) keep the same semantics as the old
+  // JacobiSVD output.
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> eig;
+  eig.computeDirect(cov, Eigen::ComputeEigenvectors);
+  const Eigen::Vector3f evals = eig.eigenvalues().cwiseMax(0.0f);
 
-  if (normal_(2) < 0) {
-    for (int i = 0; i < 3; i++) normal_(i) *= -1;
-  }
+  normal_ = eig.eigenvectors().col(0);
+  if (normal_(2) < 0.0f) normal_ = -normal_;
 
-  // mean ground seeds value
-  Eigen::Vector3f seeds_mean = pc_mean_.head<3>();
+  singular_values_ << evals(2), evals(1), evals(0);
 
   // according to normal.T*[x,y,z] = -d
-  d_ = -(normal_.transpose() * seeds_mean)(0, 0);
+  d_ = -normal_.dot(pc_mean_);
 }
 
 void PatchWorkpp::extract_initial_seeds(const int zone_idx,
@@ -201,7 +227,7 @@ void PatchWorkpp::estimateGround(Eigen::MatrixXf cloud_in) {
   // benefit from TBB because it has no R-VPF and fewer allocations
   // per patch.
   for (int zone_idx = 0; zone_idx < params_.num_zones; ++zone_idx) {
-    auto zone = ConcentricZoneModel_[zone_idx];
+    auto &zone = ConcentricZoneModel_[zone_idx];
 
     for (int ring_idx = 0; ring_idx < params_.num_rings_each_zone[zone_idx]; ++ring_idx) {
       const int num_sectors = params_.num_sectors_each_zone[zone_idx];
@@ -275,7 +301,7 @@ void PatchWorkpp::estimateGround(Eigen::MatrixXf cloud_in) {
         if (params_.enable_TGR) {
           temporal_ground_revert(ringwise_flatness, candidates, concentric_idx);
         } else {
-          for (auto candidate : candidates) {
+          for (auto &candidate : candidates) {
             addCloud(cloud_nonground_, candidate.regionwise_ground);
           }
         }
@@ -391,8 +417,8 @@ void PatchWorkpp::reflected_noise_removal(Eigen::MatrixXf &cloud_in) {
     cout << "PatchWorkpp::reflected_noise_removal() - Number of Noises : " << cnt << endl;
 }
 
-void PatchWorkpp::temporal_ground_revert(std::vector<double> ring_flatness,
-                                         std::vector<patchwork::RevertCandidate> candidates,
+void PatchWorkpp::temporal_ground_revert(const std::vector<double> &ring_flatness,
+                                         const std::vector<patchwork::RevertCandidate> &candidates,
                                          int concentric_idx) {
   if (params_.verbose)
     std::cout << "\033[1;34m"
@@ -408,7 +434,7 @@ void PatchWorkpp::temporal_ground_revert(std::vector<double> ring_flatness,
          << std::endl;
   }
 
-  for (auto candidate : candidates) {
+  for (const auto &candidate : candidates) {
     // Debug
     if (params_.verbose) {
       cout << "\033[1;33m" << candidate.sector_idx << "th flat_sector_candidate"
@@ -470,26 +496,29 @@ void PatchWorkpp::extract_piecewiseground(const int zone_idx,
 
   // 1. Region-wise Vertical Plane Fitting (R-VPF)
   // : removes potential vertical plane under the ground plane
-  vector<PointXYZ> src_wo_verticals;
-  src_wo_verticals = src;
+  // src_wo_verticals_ and src_tmp_ are reused instance scratch buffers
+  // (see header) — `clear()` keeps capacity, so the per-patch malloc
+  // pressure on the glibc heap goes away after the first few patches.
+  src_wo_verticals_.clear();
+  src_wo_verticals_.insert(src_wo_verticals_.end(), src.begin(), src.end());
 
   if (params_.enable_RVPF) {
     for (int i = 0; i < params_.num_iter; i++) {
-      extract_initial_seeds(zone_idx, src_wo_verticals, ground_pc_, params_.th_seeds_v);
+      extract_initial_seeds(zone_idx, src_wo_verticals_, ground_pc_, params_.th_seeds_v);
       estimate_plane(ground_pc_);
 
       if (zone_idx == 0 && normal_(2) < params_.uprightness_thr) {
-        vector<PointXYZ> src_tmp;
-        src_tmp = src_wo_verticals;
-        src_wo_verticals.clear();
+        src_tmp_.clear();
+        src_tmp_.swap(src_wo_verticals_);  // src_tmp_ now holds the old src_wo_verticals_;
+                                           // src_wo_verticals_ is empty (capacity retained).
 
-        for (auto point : src_tmp) {
+        for (const auto &point : src_tmp_) {
           double distance = calc_point_to_plane_d(point, normal_, d_);
 
           if (abs(distance) < params_.th_dist_v) {
             non_ground_dst.push_back(point);
           } else {
-            src_wo_verticals.push_back(point);
+            src_wo_verticals_.push_back(point);
           }
         }
       } else
@@ -500,13 +529,13 @@ void PatchWorkpp::extract_piecewiseground(const int zone_idx,
   // 2. Region-wise Ground Plane Fitting (R-GPF)
   // : fits the ground plane
 
-  extract_initial_seeds(zone_idx, src_wo_verticals, ground_pc_);
+  extract_initial_seeds(zone_idx, src_wo_verticals_, ground_pc_);
   estimate_plane(ground_pc_);
 
   for (int i = 0; i < params_.num_iter; i++) {
     ground_pc_.clear();
 
-    for (auto point : src_wo_verticals) {
+    for (const auto &point : src_wo_verticals_) {
       double distance = calc_point_to_plane_d(point, normal_, d_);
 
       if (i < params_.num_iter - 1) {
@@ -538,11 +567,13 @@ void PatchWorkpp::extract_piecewiseground(const int zone_idx,
   }
 }
 
-double PatchWorkpp::calc_point_to_plane_d(PointXYZ p, Eigen::VectorXf normal, double d) {
+double PatchWorkpp::calc_point_to_plane_d(const PointXYZ &p,
+                                          const Eigen::VectorXf &normal,
+                                          double d) {
   return normal(0) * p.x + normal(1) * p.y + normal(2) * p.z + d;
 }
 
-void PatchWorkpp::calc_mean_stdev(std::vector<double> vec, double &mean, double &stdev) {
+void PatchWorkpp::calc_mean_stdev(const std::vector<double> &vec, double &mean, double &stdev) {
   if (vec.size() <= 1) return;
 
   mean = std::accumulate(vec.begin(), vec.end(), 0.0) / vec.size();


### PR DESCRIPTION
## Summary

Cuts per-frame Patchwork++ time on KITTI seq 00 from **10.26 ms → 8.94 ms** (97.5 Hz → **111.9 Hz**, +14.8% Hz, median of 3 runs, i7-12700). Patchwork classic is unaffected (already TBB-bound, see #95).

The win comes from killing short-lived heap allocations in the per-patch hot loop, exactly the bottleneck identified in #96.

## What changed

**High-impact (this is where the 14.8% comes from):**

1. `PatchWorkpp::estimate_plane`: drop `Eigen::MatrixX3f eigen_ground` + `centered` + `centered.adjoint() * centered`. Replace with a single-pass scalar accumulation of mean and 9 cross-products, then build the 3×3 cov on the stack. No more per-call Eigen heap allocations.
2. `PatchWorkpp::extract_piecewiseground`: promote `src_wo_verticals` and `src_tmp` to reused instance scratch members. `vector::clear()` keeps capacity, so per-patch malloc pressure on the glibc heap (which was serializing the loop per #96) drops away after the first few patches.
3. `PatchWorkpp::estimateGround` main loop: `auto& zone` instead of `auto zone` for `ConcentricZoneModel_[zone_idx]`. Avoids a deep-copy of the full 3-level nested vector per outer iteration. Safe: the in-place `std::sort` mutates patches that are read once and then flushed at the top of every `estimateGround` call.

**Lower-impact, kept for cleanliness:**

4. `JacobiSVD<Matrix3f>` → `SelfAdjointEigenSolver::computeDirect` for the 3×3 PSD covariance in both `cpp/common/src/plane_fit.cpp` and the in-place `PatchWorkpp::estimate_plane`. Closed-form, no Jacobi iterations. `singular_values_` is repacked descending so every consumer (linearity/planarity in `common`, `flatness_thr` index `(2)` in patchwork classic, `ground_flatness=minCoeff()` and `line_variable=sv(0)/sv(1)` in patchwork++) keeps the same convention bit-for-bit.
5. `const&` on `addCloud`'s `add` parameter, `RevertCandidate` loop vars, and the `temporal_ground_revert` / `calc_point_to_plane_d` / `calc_mean_stdev` signatures.

## Benchmarks

KITTI seq 00, 2900 timed frames, median of 3 runs:

| Stage | patchwork++ | patchwork (classic) |
|---|---|---|
| baseline (JacobiSVD + per-call allocs) | 10.26 ms / 97.5 Hz | 4.26 ms / 234.7 Hz |
| eigh only                                | 9.94 ms / 100.6 Hz (+3.2%) | 4.30 ms / 232.8 Hz (noise) |
| eigh + alloc-free                         | **8.94 ms / 111.9 Hz (+14.8%)** | 4.29 ms / 232.9 Hz (noise) |

Patchwork classic is unchanged on the perf side: TBB parallel_for already amortizes allocations across 24 cores and SVD is sub-µs/patch.

## Numerical equivalence

Full KITTI seq 00 (4541 frames):

| method (protocol) | before | after | Δ |
|---|---|---|---|
| patchwork (pw)   | P 92.34, R 94.64, F1 93.41 | P 92.34, R 94.64, F1 93.41 | **0.00** |
| patchwork++ (pp) | P 94.88, R 98.47, F1 96.62 | P 94.89, R 98.48, F1 96.63 | **+0.01 F1** |

Algebraic identity of JacobiSVD vs eigh verified on 500 real KITTI patch covariances: `normal_` (up to sign), `singular_values_`, `linearity_`, `planarity_`, `ground_flatness`, and `line_variable` all match to FP precision. All deltas well within the ±0.05 macro / ±0.10 per-seq budget.

Refs #96.

## Test plan

- [x] `pip install -v ./python/` builds clean on Linux (gcc 13)
- [x] `evaluate_semantickitti.py --method patchworkpp --eval_protocol patchworkpp --seqs 00` matches baseline within ±0.05 F1
- [x] `evaluate_semantickitti.py --method patchwork --eval_protocol patchwork --seqs 00` bit-identical to baseline
- [x] `bench_hz.py --method patchworkpp --seq 00`: +14.8% Hz, stable across 3 runs
- [x] `bench_hz.py --method patchwork --seq 00`: within run-to-run noise of baseline
- [ ] CI matrix (Linux/macOS/Windows wheels + ros2_node + cpp_api) green